### PR TITLE
Adding strict option

### DIFF
--- a/lib/complete.js
+++ b/lib/complete.js
@@ -5,17 +5,25 @@ import debounce from 'tinybounce';
 import { on, addClass, removeClass, find } from 'domassist';
 
 const DOMAssist = { on, addClass, removeClass, find };
+const KEYS = {
+  ENTER: 13,
+  UP: 38,
+  DOWN: 40
+};
 
 export default class Complete extends Domodule {
   postInit() {
     this.currentIndex = -1;
-    DOMAssist.on(this.els.input, 'keyup', event => this.keyup(event));
+    DOMAssist.on(this.els.input, 'keydown', event => this.keydown(event));
     this.fetch = debounce(this.fetch.bind(this), this.options.delay);
+    this.options.strict = this.options.strict === true ||
+        this.options.strict === 'true';
   }
 
   get defaults() {
     return {
       delay: 500,
+      strict: true,
       showClass: 'show',
       highlightClass: 'selected'
     };
@@ -86,11 +94,15 @@ export default class Complete extends Domodule {
   }
 
   select(el, event, options) {
-    this.selectedTerm = { value: options.value, name: el.innerHTML };
-    this.els.input.value = this.selectedTerm.name;
+    this.updateValue({ value: options.value, name: el.innerHTML });
+  }
+
+  updateValue(value) {
+    this.selectedTerm = value;
+    this.els.input.value = value.name;
 
     if (this.els.value) {
-      this.els.value.value = this.selectedTerm.value;
+      this.els.value.value = value.value;
     }
   }
 
@@ -132,7 +144,12 @@ export default class Complete extends Domodule {
     const items = find('li', this.els.resultsContainer);
 
     if (this.currentIndex < 0) {
-      this.currentIndex = 0;
+      if (this.options.strict) {
+        this.currentIndex = 0;
+      } else {
+        this.updateValue({ value: this.els.input.value, name: this.els.input.value });
+        return;
+      }
     }
 
     if (this.currentIndex >= items.length) {
@@ -143,9 +160,9 @@ export default class Complete extends Domodule {
     DOMAssist.removeClass(items[this.currentIndex], this.options.highlightClass);
   }
 
-  keyup(event) {
+  keydown(event) {
     switch (event.keyCode) {
-      case 38: // ArrowUp
+      case KEYS.UP:
         if (this.currentIndex > 0) {
           --this.currentIndex;
         }
@@ -153,13 +170,13 @@ export default class Complete extends Domodule {
         this.highlightItem();
 
         break;
-      case 40: // ArrowDown
+      case KEYS.DOWN:
         ++this.currentIndex;
 
         this.highlightItem();
 
         break;
-      case 13: // Enter
+      case KEYS.ENTER:
         this.selectItem();
 
         break;

--- a/test/complete.test.js
+++ b/test/complete.test.js
@@ -22,8 +22,8 @@ const setup = () => {
       <div data-name="resultsContainer"></div>
     </div>
   `;
-  const modules = Complete.discover();
-  return modules;
+
+  return Complete.discover();
 };
 
 init();
@@ -98,4 +98,35 @@ test('keyboard', assert => {
 
   instance.els.input.focus();
   page.sendEvent('keypress', 'a');
+  page.sendEvent('keypress', 16777235); // up
+  page.sendEvent('keypress', 'b');
+  assert.equal(instance.els.input.value, 'ab', 'Cursor caret doesn\'t move with up/down arrows');
+});
+
+test('strict', assert => {
+  const container = document.getElementById('domodule');
+  container.innerHTML = `
+    <div data-module="Complete" data-module-endpoint="${testEndpoint}" data-module-strict="false" data-module-highlight-class="complete-selected">
+      <input type="text" data-name="input" data-action="search" data-action-type="input" placeholder="Search for something">
+      <input type="hidden" data-name="value">
+      <div data-name="resultsContainer"></div>
+    </div>
+  `;
+
+  const modules = Complete.discover();
+  const instance = modules[0];
+
+  setTimeout(() => {
+    page.sendEvent('keypress', 16777221); // enter
+
+    assert.equal(instance.els.value.value, 'ab', 'Value copied as is to value');
+    assert.equal(instance.els.input.value, 'ab', 'Value is the same on the input');
+
+    assert.end();
+  }, 1000);
+
+  instance.els.input.focus();
+  page.sendEvent('keypress', 'a');
+  page.sendEvent('keypress', 'b');
+  console.log(instance.els.value.value);
 });


### PR DESCRIPTION
This adds the strict option which is true by default. It allows a non-enforced value to be entered and copied as is.
Keyup switched by keydown to avoid arrows changing cursor caret.